### PR TITLE
Add PyTorch + PytorchLightning Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Lightning
+lightning_logs/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BReG-NeXt
+
 Implementation of the paper **BReG-NeXt: Facial Affect Computing Using Adaptive Residual Networks With Bounded Gradient**
 
-
-BReG-NeXt paper can be found on 
+BReG-NeXt paper can be found on
 [IEEE Xplore](https://ieeexplore.ieee.org/document/9064942) and
 [arXiv](https://arxiv.org/abs/2004.08495)
 
@@ -11,15 +11,19 @@ BReG-NeXt paper can be found on
 # Requirements
 
 Tensorflow 1.14.0 is suggested to run the code. For installing the rest of the required packages, run the following command:
+
 ```
 pip install -r requirements.txt
 ```
+
 # Content
-* tfrecords: Sample tfrecords for training and validation from FER2013 database
-* Snapshots: Example model trained on AffectNet database on BReG-NeXt-50
-* Logs: Log report of the BReG-NeXt-50 trained model on AffectNet database
+
+- tfrecords: Sample tfrecords for training and validation from FER2013 database
+- Snapshots: Example model trained on AffectNet database on BReG-NeXt-50
+- Logs: Log report of the BReG-NeXt-50 trained model on AffectNet database
 
 # Pre-Trained Parameters
+
 As mentioned above trained parameters on the AffectNet database on BReG-NeXt-50 is provided in the [Snapshots folder](https://github.com/behzadhsni/BReG-NeXt/tree/master/codes/Snapshots/categorical_attempt_1). You can find various trained parameter values in this file. More specifically, the adaptive coefficient (alpha and beta) are stored in variables that have the following regex:
 
 ```
@@ -27,7 +31,9 @@ ResidualBlock[_]*[1-9]*/shortcut_mod[_]*[1-9]*/[a,c][_]*[1-9]*
 ```
 
 # How To Run
+
 Simply run the `BReG-NeXt.py` file:
+
 ```
 codes/>> python BReG-NeXt.py
 ```
@@ -36,19 +42,44 @@ codes/>> python BReG-NeXt.py
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/psnegi/BReG-NeXt/master?filepath=codes%2FBReG_NeXt.ipynb)
 
-
 # Write Your Own Complex Mapping
-To write your own customized complex mapping (given the restrictions and properties mentioned in the [BReG-NeXt paper](https://ieeexplore.ieee.org/document/9064942)), you need to modify [Lines 136 to 140](https://github.com/behzadhsni/BReG-NeXt/blob/master/codes/BReG-NeXt.py#L136) of the ```BReG-NeXt.py``` file. Simply write your own function for the mapping and assign it to the ```identity``` variable.
+
+To write your own customized complex mapping (given the restrictions and properties mentioned in the [BReG-NeXt paper](https://ieeexplore.ieee.org/document/9064942)), you need to modify [Lines 136 to 140](https://github.com/behzadhsni/BReG-NeXt/blob/master/codes/BReG-NeXt.py#L136) of the `BReG-NeXt.py` file. Simply write your own function for the mapping and assign it to the `identity` variable.
 
 ```
  with tf.name_scope('shortcut_mod'): # Write your customized function
   multiplier1 = tf.Variable(1, dtype=tf.float32, trainable=True, name='alpha') # first optional coefficient
   multiplier2 = tf.Variable(1, dtype=tf.float32, trainable=True, name='beta') # second optional coefficient
-  with tf.name_scope('shortcut_mod_function'): 
+  with tf.name_scope('shortcut_mod_function'):
     identity = your_function(multiplier1, multiplier2) # must assign your function to the 'identity' variable
 ```
 
+# Running on PyTorch
+
+This repository also supports running on PyTorch with PyTorch lightning. The models can be found in the `codes/torch/` directory.
+
+The requirements (which can be installed with pip) are listed in `codes/torch/requirements.txt`.
+
+To train a model with PyTorch, you should use:
+
+```bash
+>> python codes/torch/trainer.py --train_data_path <path to train tfrecord> --val_data_path <path to val tfrecord>
+```
+
+To enable GPU training, pass a non-zero value to the trainer:
+
+```bash
+>> python codes/torch/trainer.py --train_data_path <path to train tfrecord> --val_data_path <path to val tfrecord> --num_gpus N
+```
+
+There are several other training options (View the docs here: https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html?highlight=Trainer). You can view them using:
+
+```bash
+>> python codes/torch/trainer.py --help
+```
+
 # Citation
+
 All submitted papers (or any publically available text) that uses the entire or parts of this code, must cite the following paper:
 
 **B. Hasani, P. S. Negi and M. Mahoor, "BReG-NeXt: Facial affect computing using adaptive residual networks with bounded gradient," in IEEE Transactions on Affective Computing, 2020.**

--- a/codes/torch/BReGNeXt.py
+++ b/codes/torch/BReGNeXt.py
@@ -5,8 +5,8 @@ import itertools
 class BRegNextShortcutModifier(torch.nn.Model):
 
     def __init__(self,):
-        self._a = torch.nn.Parameter(1, dtype=torch.float32, requires_grad=True)
-        self._c = torch.nn.Parameter(1, dtype=torch.float32, requires_grad=True)
+        self._a = torch.nn.Parameter(torch.FloatTensor([1.0]), requires_grad=True)
+        self._c = torch.nn.Parameter(torch.FloatTensor([1.0]), requires_grad=True)
 
     def forward(self, inputs):
         numl = torch.atan((self._a * inputs) / torch.sqrt(self._c ** 2 + 1))

--- a/codes/torch/BReGNeXt.py
+++ b/codes/torch/BReGNeXt.py
@@ -1,0 +1,85 @@
+
+import torch
+import itertools
+
+class BRegNextShortcutModifier(torch.nn.Model):
+
+    def __init__(self,):
+        self._a = torch.nn.Parameter(1, dtype=torch.float32, requires_grad=True)
+        self._c = torch.nn.Parameter(1, dtype=torch.float32, requires_grad=True)
+
+    def forward(self, inputs):
+        numl = torch.atan((self._a * inputs) / torch.sqrt(self._c ** 2 + 1))
+        denom = self._a * torch.sqrt(self._c ** 2 + 1)
+        return  (numl / denom)
+
+
+class BReGNeXtResidualLayer(torch.nn.Model):
+
+    def __init__(self, in_channels: int, out_channels: int, downsample_stride: int=1):
+        self._out_channels = out_channels
+        self._in_channels = in_channels
+        self._downsample_stride = 1 if downsample is None else downsample
+
+        # TODO: These may have slightly different layer initializations.
+        self._conv0 = torch.nn.Conv2d(in_channels, out_channels, 3, downsample_stride)
+        self._conv0 = torch.nn.Conv2d(out_channels, out_channels, 3, 1)
+        self._shortcut = BRegNextShortcutModifier()
+        self._batchnorm_conv0 = torch.nn.BatchNorm2d(self._in_channels)
+        self._batchnorm_conv1 = torch.nn.BatchNorm2d(self._out_channels)
+
+    def forward(self, inputs):
+        # First convolution
+        normed_inputs = inputs if self._batchnorm_conv0 is None else self._batchnorm_conv0(inputs)
+        normed_inputs = torch.nn.functional.elu(normed_inputs)
+        conv0_outputs = self._conv0(normed_inputs)
+
+        # Second convolution
+        normed_conv0_outputs = conv0_outputs if self._batchnorm_conv1 is None else self._batchnorm_conv1(conv0_outputs)
+        normed_conv0_outputs = torch.nn.functional.elu(normed_conv0_outputs)
+        conv1_outputs = self._conv1(normed_conv0_outputs)
+
+        # TODO: Are the shortcut weights always the same for every layer?
+        shortcut_modifier = self._shortcut(inputs)
+        if self._downsample_stride > 1:
+            shortcut_modifier = torch.nn.functional.avg_pool2d(shortcut_modifier, self._downsample_stride, self._downsample_stride)
+
+        # Downsample the projection
+        if self._out_channels != self._in_channels:
+            pad_dimension = (self._out_channels - self._in_channels) // 2
+            shortcut_modifier = torch.nn.functional.pad(shortcut_modifier, [pad_dimension, pad_dimension])
+
+        return conv1_outputs + shortcut_modifier
+
+
+class BRegNextResidualBlock(torch.nn.Module):
+
+    def forward(self, inputs):
+        # TODO: Adjust the layer stack, since the number of channels will be different for the first block vs. the other blocks
+        return self._layer_stack(inputs)
+
+
+class BReG_NeXt(torch.nn.Module):
+
+    def __init__(self, n_classes: int = 8) -> None:
+        self._model = torch.nn.Sequential(
+            torch.nn.Conv2D(in_channels=3, out_channels=32),
+            BRegNextResidualBlock(n_blocks=7, in_channels=32, out_channels=32),
+            BRegNextResidualBlock(n_blocks=1, in_channels=32, out_channels=64, downsample_stride=2),
+            BRegNextResidualBlock(n_blocks=8, in_channels=64, out_channels=64),
+            BRegNextResidualBlock(n_blocks=1, in_channels=64, out_channels=128, downsample_stride=2),
+            BRegNextResidualBlock(n_blocks=7, in_channels=128, out_channels=128),
+            torch.nn.BatchNorm2d(128),
+            torch.nn.ELU(),
+            torch.nn.AdaptiveAvgPool2d((1,1)),
+        )
+        self._fc0 = torch.nn.Linear(128, n_classes)
+
+    def conv0_params(self,):
+        return self._conv0.parameters()
+
+    def model_params(self,):
+        return itertools.chain.from_iterable([self._fc0.parameters(), self._model.parameters()])
+
+    def forward(self, x):
+        return self._fc0(self._model(x).reshape(-1, 128))

--- a/codes/torch/LICENSE
+++ b/codes/torch/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Regents of the University of California
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/codes/torch/inspect_checkpoint.py
+++ b/codes/torch/inspect_checkpoint.py
@@ -1,0 +1,203 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""A simple script for inspect checkpoint files."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import re
+import sys
+
+import numpy as np
+
+from tensorflow.python.platform import app
+from tensorflow.python.platform import flags
+from tensorflow.python.training import py_checkpoint_reader
+
+FLAGS = None
+
+
+def _count_total_params(reader, count_exclude_pattern=""):
+  """Count total number of variables."""
+  var_to_shape_map = reader.get_variable_to_shape_map()
+
+  # Filter out tensors that we don't want to count
+  if count_exclude_pattern:
+    regex_pattern = re.compile(count_exclude_pattern)
+    new_var_to_shape_map = {}
+    exclude_num_tensors = 0
+    exclude_num_params = 0
+    for v in var_to_shape_map:
+      if regex_pattern.search(v):
+        exclude_num_tensors += 1
+        exclude_num_params += np.prod(var_to_shape_map[v])
+      else:
+        new_var_to_shape_map[v] = var_to_shape_map[v]
+    var_to_shape_map = new_var_to_shape_map
+    print("# Excluding %d tensors (%d params) that match %s when counting." % (
+        exclude_num_tensors, exclude_num_params, count_exclude_pattern))
+
+  var_sizes = [np.prod(var_to_shape_map[v]) for v in var_to_shape_map]
+  return np.sum(var_sizes, dtype=int)
+
+
+def print_tensors_in_checkpoint_file(file_name, tensor_name, all_tensors,
+                                     all_tensor_names=False,
+                                     count_exclude_pattern=""):
+  """Prints tensors in a checkpoint file.
+
+  If no `tensor_name` is provided, prints the tensor names and shapes
+  in the checkpoint file.
+
+  If `tensor_name` is provided, prints the content of the tensor.
+
+  Args:
+    file_name: Name of the checkpoint file.
+    tensor_name: Name of the tensor in the checkpoint file to print.
+    all_tensors: Boolean indicating whether to print all tensors.
+    all_tensor_names: Boolean indicating whether to print all tensor names.
+    count_exclude_pattern: Regex string, pattern to exclude tensors when count.
+  """
+  try:
+    reader = py_checkpoint_reader.NewCheckpointReader(file_name)
+    if all_tensors or all_tensor_names:
+      var_to_shape_map = reader.get_variable_to_shape_map()
+      var_to_dtype_map = reader.get_variable_to_dtype_map()
+      for key, value in sorted(var_to_shape_map.items()):
+        print("tensor: %s (%s) %s" % (key, var_to_dtype_map[key].name, value))
+        if all_tensors:
+          print(reader.get_tensor(key))
+    elif not tensor_name:
+      print(reader.debug_string().decode("utf-8", errors="ignore"))
+    else:
+      if not reader.has_tensor(tensor_name):
+        print("Tensor %s not found in checkpoint" % tensor_name)
+        return
+
+      var_to_shape_map = reader.get_variable_to_shape_map()
+      var_to_dtype_map = reader.get_variable_to_dtype_map()
+      print("tensor: %s (%s) %s" %
+            (tensor_name, var_to_dtype_map[tensor_name].name,
+             var_to_shape_map[tensor_name]))
+      print(reader.get_tensor(tensor_name))
+
+    # Count total number of parameters
+    print("# Total number of params: %d" % _count_total_params(
+        reader, count_exclude_pattern=count_exclude_pattern))
+  except Exception as e:  # pylint: disable=broad-except
+    print(str(e))
+    if "corrupted compressed block contents" in str(e):
+      print("It's likely that your checkpoint file has been compressed "
+            "with SNAPPY.")
+    if ("Data loss" in str(e) and
+        any(e in file_name for e in [".index", ".meta", ".data"])):
+      proposed_file = ".".join(file_name.split(".")[0:-1])
+      v2_file_error_template = """
+It's likely that this is a V2 checkpoint and you need to provide the filename
+*prefix*.  Try removing the '.' and extension.  Try:
+inspect checkpoint --file_name = {}"""
+      print(v2_file_error_template.format(proposed_file))
+
+
+def parse_numpy_printoption(kv_str):
+  """Sets a single numpy printoption from a string of the form 'x=y'.
+
+  See documentation on numpy.set_printoptions() for details about what values
+  x and y can take. x can be any option listed there other than 'formatter'.
+
+  Args:
+    kv_str: A string of the form 'x=y', such as 'threshold=100000'
+
+  Raises:
+    argparse.ArgumentTypeError: If the string couldn't be used to set any
+        nump printoption.
+  """
+  k_v_str = kv_str.split("=", 1)
+  if len(k_v_str) != 2 or not k_v_str[0]:
+    raise argparse.ArgumentTypeError("'%s' is not in the form k=v." % kv_str)
+  k, v_str = k_v_str
+  printoptions = np.get_printoptions()
+  if k not in printoptions:
+    raise argparse.ArgumentTypeError("'%s' is not a valid printoption." % k)
+  v_type = type(printoptions[k])
+  if v_type is type(None):
+    raise argparse.ArgumentTypeError(
+        "Setting '%s' from the command line is not supported." % k)
+  try:
+    v = (
+        v_type(v_str)
+        if v_type is not bool else flags.BooleanParser().parse(v_str))
+  except ValueError as e:
+    raise argparse.ArgumentTypeError(e.message)
+  np.set_printoptions(**{k: v})
+
+
+def main(unused_argv):
+  if not FLAGS.file_name:
+    print("Usage: inspect_checkpoint --file_name=checkpoint_file_name "
+          "[--tensor_name=tensor_to_print] "
+          "[--all_tensors] "
+          "[--all_tensor_names] "
+          "[--printoptions]")
+    sys.exit(1)
+  else:
+    print_tensors_in_checkpoint_file(
+        FLAGS.file_name, FLAGS.tensor_name,
+        FLAGS.all_tensors, FLAGS.all_tensor_names,
+        count_exclude_pattern=FLAGS.count_exclude_pattern)
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.register("type", "bool", lambda v: v.lower() == "true")
+  parser.add_argument(
+      "--file_name",
+      type=str,
+      default="",
+      help="Checkpoint filename. "
+      "Note, if using Checkpoint V2 format, file_name is the "
+      "shared prefix between all files in the checkpoint.")
+  parser.add_argument(
+      "--tensor_name",
+      type=str,
+      default="",
+      help="Name of the tensor to inspect")
+  parser.add_argument(
+      "--count_exclude_pattern",
+      type=str,
+      default="",
+      help="Pattern to exclude tensors, e.g., from optimizers, when counting.")
+  parser.add_argument(
+      "--all_tensors",
+      nargs="?",
+      const=True,
+      type="bool",
+      default=False,
+      help="If True, print the names and values of all the tensors.")
+  parser.add_argument(
+      "--all_tensor_names",
+      nargs="?",
+      const=True,
+      type="bool",
+      default=False,
+      help="If True, print the names of all the tensors.")
+  parser.add_argument(
+      "--printoptions",
+      nargs="*",
+      type=parse_numpy_printoption,
+      help="Argument for numpy.set_printoptions(), in the form 'k=v'.")
+  FLAGS, unparsed = parser.parse_known_args()
+  app.run(main=main, argv=[sys.argv[0]] + unparsed)

--- a/codes/torch/requirements.txt
+++ b/codes/torch/requirements.txt
@@ -1,0 +1,3 @@
+torch>=1.7.0
+pytorch_lightning>=1.0.3
+tfrecord>=1.11

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -1,23 +1,105 @@
+# Copyright (c) 2021 Regents of the University of California
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
 
+from argparse import ArgumentParser
+
+import cv2
 import torch
+import torchvision
+import tfrecord
 import pytorch_lightning
+import random
 
-from .BReGNeXt import BReG_NeXt
+from BReGNeXt import BReGNeXt
+from utils import ShuffleDataset
+
+
+def focal_loss2(input_tensor, target_tensor, weight=None, gamma=2, reduction='mean'):
+    log_prob = torch.nn.functional.log_softmax(input_tensor, dim=-1)
+    probs = torch.exp(log_prob)
+    return torch.nn.functional.nll_loss(((1 - probs) ** gamma) * log_prob,
+                                        target_tensor, weight=weight, reduction=reduction)
+
+
+_image_transform = torchvision.transforms.Compose([
+    torchvision.transforms.ToPILImage(),
+    torchvision.transforms.RandomHorizontalFlip(),
+    torchvision.transforms.ColorJitter(brightness=(0, 0.05), contrast=(0.7,1.3), saturation=(0.6, 1.6), hue=0.08),
+    torchvision.transforms.RandomResizedCrop((64,64)),
+    torchvision.transforms.ToTensor(),
+])
+
+
+def decode_and_preprocess_image(features):
+    # Decode the image
+    features['image_raw'] = features['image_raw'].reshape(64, 64, 3)
+    features['image_raw'] = _image_transform(features['image_raw'])
+    features['image_raw'] = features['image_raw'] - torch.FloatTensor([0.5727663, 0.44812188, 0.39362228]).unsqueeze(-1).unsqueeze(-1)
+    features['label'] = torch.LongTensor(features['label'])
+    return features
+
 
 class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
 
-    def __init__(self,):
-        self._model = BReG_NeXt()
+    def __init__(self, use_focal_loss = False):
 
-    def training_step(self, batch):
-        pass
+        super(BReGNeXtPTLDriver, self).__init__()
 
-    def validation_step(self, batch):
-        pass
+        self._use_focal_loss = use_focal_loss
+        self._model = BReGNeXt()
+
+    def training_step(self, batch, batch_idx):
+        logits = self._model(batch['image_raw'])
+        batch['label'] = batch['label'].reshape(-1)
+        loss = focal_loss2(logits, batch['label']) if self._use_focal_loss else torch.nn.functional.cross_entropy(logits, batch['label'])
+        accuracy = (logits.argmax(dim=-1) == batch['label']).float().mean()
+
+        self.log('train/accuracy', accuracy, prog_bar=True)
+        self.log('train/loss', loss, prog_bar=True)
+
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        logits = self._model(batch['image_raw'])
+        batch['label'] = batch['label'].reshape(-1)
+        loss = focal_loss2(logits, batch['label']) if self._use_focal_loss else torch.nn.functional.cross_entropy(logits, batch['label'])
+        accuracy = (logits.argmax(dim=-1) == batch['label']).float().mean()
+
+        self.log('val/accuracy', accuracy, prog_bar=True)
+        self.log('val/loss', loss, prog_bar=True)
+
+        return loss
 
     def configure_optimizers(self):
-
-        optimizer = torch.optim.Adam([{'params': self._model.conv0_params(), 'weight_decay': 0.0001},
-                                      {'params': self._model.model_params()}], lr=learning_rate)
+        optimizer = torch.optim.Adam(self._model.parameters(), lr=0.0001, weight_decay=0.0001)
         scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.80)
         return [optimizer], [scheduler]
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser = pytorch_lightning.Trainer.add_argparse_args(parser)
+    args = parser.parse_args()
+
+    train_dataset = ShuffleDataset(tfrecord.torch.dataset.TFRecordDataset(
+        data_path='/home/david/Projects/BReG-NeXt/tfrecords/training_FER2013_sample.tfrecords',
+        index_path=None,
+        description={'image_raw': 'byte', 'label': 'int'},
+        transform=decode_and_preprocess_image,
+    ), 1024)
+    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=64, num_workers=12)
+
+    valid_dataset = tfrecord.torch.dataset.TFRecordDataset(
+        data_path='/home/david/Projects/BReG-NeXt/tfrecords/validation_FER2013_sample.tfrecords',
+        index_path=None,
+        description={'image_raw': 'byte', 'label': 'int'},
+        transform=decode_and_preprocess_image,
+    )
+    valid_dataloader = torch.utils.data.DataLoader(valid_dataset, batch_size=64, num_workers=12)
+
+    # Fit the model to the trainer.
+    model = BReGNeXtPTLDriver()
+    trainer = pytorch_lightning.Trainer.from_argparse_args(args)
+    trainer.fit(model, train_dataloader, valid_dataloader)

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -72,7 +72,7 @@ class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
         return loss
 
     def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self._model.parameters(), lr=(self.lr or self.learning_rate), weight_decay=0.0001)
+        optimizer = torch.optim.Adam(self._model.parameters(), lr=self.learning_rate, weight_decay=0.0001)
         scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.80)
         return [optimizer], [scheduler]
 

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -80,6 +80,7 @@ class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
 
 if __name__ == '__main__':
     parser = ArgumentParser()
+    parser.add_argument('--use_focal_loss', action='store_true', help='Use focal loss when training.')
     parser = pytorch_lightning.Trainer.add_argparse_args(parser)
     args = parser.parse_args()
 
@@ -89,7 +90,7 @@ if __name__ == '__main__':
         description={'image_raw': 'byte', 'label': 'int'},
         transform=decode_and_preprocess_image,
     ), 1024)
-    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=64, num_workers=12)
+    train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=64, num_workers=4)
 
     valid_dataset = tfrecord.torch.dataset.TFRecordDataset(
         data_path='/home/david/Projects/BReG-NeXt/tfrecords/validation_FER2013_sample.tfrecords',
@@ -97,9 +98,9 @@ if __name__ == '__main__':
         description={'image_raw': 'byte', 'label': 'int'},
         transform=decode_and_preprocess_image,
     )
-    valid_dataloader = torch.utils.data.DataLoader(valid_dataset, batch_size=64, num_workers=12)
+    valid_dataloader = torch.utils.data.DataLoader(valid_dataset, batch_size=64, num_workers=4)
 
     # Fit the model to the trainer.
-    model = BReGNeXtPTLDriver()
+    model = BReGNeXtPTLDriver(use_focal_loss=args.use_focal_loss)
     trainer = pytorch_lightning.Trainer.from_argparse_args(args)
     trainer.fit(model, train_dataloader, valid_dataloader)

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -41,11 +41,12 @@ def decode_and_preprocess_image(features):
 
 class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
 
-    def __init__(self, use_focal_loss = False):
+    def __init__(self, use_focal_loss = False, learning_rate = 0.0001):
 
         super(BReGNeXtPTLDriver, self).__init__()
 
         self._use_focal_loss = use_focal_loss
+        self.learning_rate = learning_rate
         self._model = BReGNeXt()
 
     def training_step(self, batch, batch_idx):
@@ -71,7 +72,7 @@ class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
         return loss
 
     def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self._model.parameters(), lr=0.0001, weight_decay=0.0001)
+        optimizer = torch.optim.Adam(self._model.parameters(), lr=(self.lr or self.learning_rate), weight_decay=0.0001)
         scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.80)
         return [optimizer], [scheduler]
 

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -1,0 +1,23 @@
+
+import torch
+import pytorch_lightning
+
+from .BReGNeXt import BReG_NeXt
+
+class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
+
+    def __init__(self,):
+        self._model = BReG_NeXt()
+
+    def training_step(self, batch):
+        pass
+
+    def validation_step(self, batch):
+        pass
+
+    def configure_optimizers(self):
+
+        optimizer = torch.optim.Adam([{'params': self._model.conv0_params(), 'weight_decay': 0.0001},
+                                      {'params': self._model.model_params()}], lr=learning_rate)
+        scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.80)
+        return [optimizer], [scheduler]

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -80,11 +80,13 @@ class BReGNeXtPTLDriver(pytorch_lightning.LightningModule):
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--use_focal_loss', action='store_true', help='Use focal loss when training.')
+    parser.add_argument('--train_data_path', type=str, help='The path to the .tfrecords file for training.', required=True)
+    parser.add_argument('--val_data_path', type=str, help='The path to the .tfrecords file for evaluation.', required=True)
     parser = pytorch_lightning.Trainer.add_argparse_args(parser)
     args = parser.parse_args()
 
     train_dataset = ShuffleDataset(tfrecord.torch.dataset.TFRecordDataset(
-        data_path='/home/david/Projects/BReG-NeXt/tfrecords/training_FER2013_sample.tfrecords',
+        data_path=args.train_data_path,
         index_path=None,
         description={'image_raw': 'byte', 'label': 'int'},
         transform=decode_and_preprocess_image,
@@ -92,7 +94,7 @@ if __name__ == '__main__':
     train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=64, num_workers=4)
 
     valid_dataset = tfrecord.torch.dataset.TFRecordDataset(
-        data_path='/home/david/Projects/BReG-NeXt/tfrecords/validation_FER2013_sample.tfrecords',
+        data_path=args.val_data_path,
         index_path=None,
         description={'image_raw': 'byte', 'label': 'int'},
         transform=decode_and_preprocess_image,

--- a/codes/torch/trainer.py
+++ b/codes/torch/trainer.py
@@ -5,12 +5,10 @@
 
 from argparse import ArgumentParser
 
-import cv2
 import torch
 import torchvision
 import tfrecord
 import pytorch_lightning
-import random
 
 from BReGNeXt import BReGNeXt
 from utils import ShuffleDataset

--- a/codes/torch/utils.py
+++ b/codes/torch/utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021 Regents of the University of California
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+import torch
+import random
+
+class ShuffleDataset(torch.utils.data.IterableDataset):
+    def __init__(self, dataset, buffer_size):
+        super().__init__()
+        self.dataset = dataset
+        self.buffer_size = buffer_size
+
+    def __iter__(self):
+        shufbuf = []
+        try:
+            dataset_iter = iter(self.dataset)
+            for i in range(self.buffer_size):
+                shufbuf.append(next(dataset_iter))
+        except:
+            self.buffer_size = len(shufbuf)
+
+        try:
+            while True:
+                try:
+                    item = next(dataset_iter)
+                    evict_idx = random.randint(0, self.buffer_size - 1)
+                    yield shufbuf[evict_idx]
+                    shufbuf[evict_idx] = item
+                except StopIteration:
+                    break
+            while len(shufbuf) > 0:
+                yield shufbuf.pop()
+        except GeneratorExit:
+            pass


### PR DESCRIPTION
This PR adds the folder `codes/torch` which contains a full reimplementation of the code in PyTorch using the Pytorch Lightning framework, 

Usage:
`python codes/torch/trainer.py --train_data_path <path to train tfrecord> --val_data_path <path to val tfrecord>`

There are a number of additional arguments added by pytorch lightning for GPU/distributed training. Use:
`python codes/torch/trainer.py --help` for full details or see: https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html?highlight=Trainer

I've tested it working with the samples, but I haven't tested it with anything larger/more complicated. Indeed, to get this working properly with PyTorch, the tfrecord datasets should be replaced with torch.utils.data.Dataset objects (see: https://pytorch.org/docs/stable/data.html)

Cheers,
David